### PR TITLE
Add required kwarg 'type' to IpAddress object.

### DIFF
--- a/src/example.py
+++ b/src/example.py
@@ -78,7 +78,7 @@ def create_container_group(resource_group_name, name, location, image, memory, c
 
    # defaults for container group
    cgroup_os_type = OperatingSystemTypes.linux
-   cgroup_ip_address = IpAddress(ports = [Port(protocol=ContainerGroupNetworkProtocol.tcp, port = port)])
+   cgroup_ip_address = IpAddress(type='public', ports = [Port(protocol=ContainerGroupNetworkProtocol.tcp, port = port)])
    image_registry_credentials = None
 
    cgroup = ContainerGroup(location = location,

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,3 @@
-azure-common==1.1.8
+azure-common==1.1.15
 azure-mgmt-resource>=1.1.0
-azure-mgmt-containerinstance==0.1.0
+azure-mgmt-containerinstance==1.1.0


### PR DESCRIPTION
Without the keyword arg `type` was getting this error:
```
 container_group_ip_address = IpAddress(ports=[Port(protocol=ContainerGroupNetworkProtocol.tcp, port=port)])
TypeError: __init__() missing 1 required keyword-only argument: 'type'
```
This adds the required `type` keyword arg and sets it to 'public' as a default.